### PR TITLE
[Feat] connectmanager에 타이머 추가

### DIFF
--- a/Kartrider/Components/Timer/iOSTimer.swift
+++ b/Kartrider/Components/Timer/iOSTimer.swift
@@ -1,0 +1,99 @@
+//
+//  iOSTimer.swift
+//  Kartrider
+//
+//  Created by jiwon on 8/19/25.
+//
+
+import SwiftUI
+import Foundation
+import Combine
+
+struct iOSTimer: View {
+    @StateObject private var iOSTimerViewModel = IOSTimerViewModel()
+    
+    var body: some View {
+        ZStack {
+            Circle()
+                .trim(from: 1 - iOSTimerViewModel.progress, to: 1)
+                .stroke(
+                    Color.orange,
+                    style: StrokeStyle(
+                        lineWidth: 2, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .frame(width: 73, height: 73)
+                .animation(
+                    .linear(duration: 1),
+                    value: iOSTimerViewModel.progress
+                )
+            Text("\(iOSTimerViewModel.time)")
+                .font(.system(.title))
+        }
+    }
+    
+}
+
+#Preview {
+    iOSTimer()
+}
+
+class IOSTimerViewModel: ObservableObject {
+
+    let connectManager = ConnectManager.shared
+
+    private var cancellable = Set<AnyCancellable>()
+
+    @Published var isTimerRunning = false
+    @Published var time = 10
+    @Published var progress: CGFloat = 1.0
+
+    private var timer: Timer?
+
+    init() {
+        connectManager.$timerEnd
+            .receive(on: DispatchQueue.main)
+            .sink { newValue in
+                if newValue != nil {
+                    self.resetState()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        self.isTimerRunning = true
+                        self.startTimer(endDate: newValue!)
+                    }
+                } else {
+                    self.stopTimer()
+                }
+                print("[DECISION] isTimerRunning: \(self.isTimerRunning)")
+            }
+            .store(in: &cancellable)
+    }
+
+    func resetState() {
+        time = 10
+        progress = 1.0
+    }
+
+    func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+        isTimerRunning = false
+    }
+
+    func startTimer(endDate: Date) {
+        stopTimer()
+
+        DispatchQueue.main.async {
+            self.isTimerRunning = true
+        }
+
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+            print("[TIMER] \(self.time)")
+            if self.time > 0 {
+                self.time -= 1
+                self.progress = CGFloat(self.time) / 10.0
+            } else {
+                self.connectManager.timerEnd = nil
+            }
+        }
+    }
+}

--- a/Kartrider/Feature/Tournament/TournamentView.swift
+++ b/Kartrider/Feature/Tournament/TournamentView.swift
@@ -11,12 +11,13 @@ import SwiftUI
 struct TournamentView: View {
     @EnvironmentObject private var coordinator: NavigationCoordinator
     @Environment(\.modelContext) private var context
-    
+
     @StateObject private var tournamentViewModel: TournamentViewModel
 
     init(content: ContentMeta) {
         _tournamentViewModel = StateObject(
-            wrappedValue: TournamentViewModel(content: content))
+            wrappedValue: TournamentViewModel(content: content)
+        )
     }
 
     var body: some View {
@@ -28,16 +29,19 @@ struct TournamentView: View {
         ) {
             VStack(spacing: 16) {
                 Divider()
-
+                iOSTimer()
                 if tournamentViewModel.isFinished,
                     let winner = tournamentViewModel.winner
                 {
                     TournamentResultView(winner: winner.name) {
                         coordinator.popToRoot()
                     }
-                } else if let (firstCandidate, secondCandiate) = tournamentViewModel.currentCandidates {
+                } else if let (firstCandidate, secondCandiate) =
+                    tournamentViewModel.currentCandidates
+                {
                     TournamentMatchView(
-                        roundDescription: tournamentViewModel.currentRoundDescription,
+                        roundDescription: tournamentViewModel
+                            .currentRoundDescription,
                         a: firstCandidate.name,
                         b: secondCandiate.name,
                         onSelectA: {
@@ -65,7 +69,6 @@ struct TournamentView: View {
     }
 }
 
-
 #Preview {
 
     let sample = ContentMeta(
@@ -75,7 +78,7 @@ struct TournamentView: View {
         hashtags: [
             Hashtag(value: "빙의"),
             Hashtag(value: "LOL"),
-            Hashtag(value: "고트")
+            Hashtag(value: "고트"),
         ],
         thumbnailName: nil
     )

--- a/Kartrider/WatchConnectivity/ConnectManager.swift
+++ b/Kartrider/WatchConnectivity/ConnectManager.swift
@@ -24,6 +24,7 @@ class ConnectManager: NSObject, WCSessionDelegate, ObservableObject {
         @Published var decisionIndex: Int = 0
         @Published var decisionCount: Int = 0
         @Published var selectedChoice: String = ""
+    @Published var timerEnd: Date? = nil
         @Published var selectedOption: StoryChoiceOption? = nil
         @Published var isTimeout: Bool? = false
         @Published var isFirstRequest: Bool = true
@@ -33,6 +34,7 @@ class ConnectManager: NSObject, WCSessionDelegate, ObservableObject {
         @Published var message: [String: Any] = [:]
         @Published var currentStage: String = ""
         @Published var hasStartedContent: Bool = false
+        @Published var timerEnd: Date? = nil
         @Published var isTimerRunning: Bool = false
         @Published var isTTSPlaying: Bool = true
         @Published var decisionIndex: Int = 0
@@ -47,6 +49,7 @@ class ConnectManager: NSObject, WCSessionDelegate, ObservableObject {
         case isFirstRequest
 
         case hasStartedContent
+        case timerEnd
         case isTimerRunning
         case isInterrupted
         case decisionCount
@@ -135,12 +138,20 @@ class ConnectManager: NSObject, WCSessionDelegate, ObservableObject {
                 ] as? Bool {
                     self.hasStartedContent = hasStartedContent
                 }
+                if let timerEnd = message[messageKey.timerEnd.rawValue] as? Date
+                {
+                    self.timerEnd = timerEnd
+                }
+
                 if let isTimerRunning = message[
                     messageKey.isTimerRunning.rawValue
                 ]
                     as? Bool
                 {
                     self.isTimerRunning = isTimerRunning
+                    if !isTimerRunning {
+                        self.timerEnd = nil
+                    }
                 }
                 if let isTTSPlaying = message[
                     messageKey.isTTSPlaying.rawValue
@@ -257,6 +268,7 @@ class ConnectManager: NSObject, WCSessionDelegate, ObservableObject {
         }
 
         func sendStageDecisionWithFirstTTS(_ decisionIndex: Int) {
+                        
             let message: [String: Any] = [
                 "currentStage": "decision",
                 "isTimerRunning": false,
@@ -270,9 +282,13 @@ class ConnectManager: NSObject, WCSessionDelegate, ObservableObject {
         }
 
         func sendStageDecisionWithFirstTimer(_ decisionIndex: Int) {
+            let endTime = Date().addingTimeInterval(10)
+            self.timerEnd = endTime
+
             let message: [String: Any] = [
                 "currentStage": "decision",
                 "isTimerRunning": true,
+                "timerEnd": endTime,
                 "decisionIndex": decisionIndex,
                 "isFirstRequest": true,
             ]
@@ -296,9 +312,13 @@ class ConnectManager: NSObject, WCSessionDelegate, ObservableObject {
         }
 
         func sendStageDecisionWithSecTimer(_ decisionIndex: Int) {
+            let endTime = Date().addingTimeInterval(10)
+            self.timerEnd = endTime
+
             let message: [String: Any] = [
                 "currentStage": "decision",
                 "isTimerRunning": true,
+                "timerEnd": endTime,
                 "decisionIndex": decisionIndex,
                 "isFirstRequest": false,
             ]
@@ -333,9 +353,13 @@ class ConnectManager: NSObject, WCSessionDelegate, ObservableObject {
         }
 
         func sendStageEndingTimer() {
+            let endTime = Date().addingTimeInterval(10)
+            self.timerEnd = endTime
+
             let message: [String: Any] = [
                 "currentStage": "ending",
                 "isTimerRunning": true,
+                "timerEnd": endTime,
             ]
             let session = WCSession.default
             if session.isReachable {


### PR DESCRIPTION
## #️⃣ 관련 이슈
> ex) 
closes #3 

---

## 💻 작업 내용


https://github.com/user-attachments/assets/642b33b0-439a-4dc3-89d9-936c04da74c8


---

## 📝 코드 설명

> 구현하면서 고려한 점, 구조를 이렇게 구성한 이유 등을 간단히 적어주세요. 

```swift
@Published var timerEnd: Date? = nil 
...
func sendStageDecisionWithFirstTimer(_ decisionIndex: Int) {
            let endTime = Date().addingTimeInterval(10)
            self.timerEnd = endTime

            let message: [String: Any] = [
                "currentStage": "decision",
                "isTimerRunning": true,
                "timerEnd": endTime,
                "decisionIndex": decisionIndex,
                "isFirstRequest": true,
            ]
            let session = WCSession.default
            if session.isReachable {
                session.sendMessage(message, replyHandler: nil)
            }
        }
``` 

- connectManager에 @Published var timerEnd: Date? = nil 를 두 기기 모두 추가 한 후 현재 시각 + 10초 후의 시간을 보냄(끝나는 시각)


---

## 📁 참고한 내용 (선택)
* (주소 첨부)
* 
---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [ ] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [ ] 사용하지 않는 코드/파일 정리
- [ ] 작업 내용 및 코드 설명 작성 


